### PR TITLE
fix: eew intensity site effect

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -28,10 +28,8 @@ import PostalCode from "./assets/json/code.json";
 import {
   calculateEpicenterDistance,
   calculateExpectedIntensity,
-  calculateIntensity,
   calculateLocalExpectedWaveTime,
   calculateWaveRadius,
-  roundIntensity,
 } from "./scripts/helper/utils";
 import { getAudio } from "./scripts/helper/audio";
 import JSZip from "jszip";
@@ -253,16 +251,10 @@ api.on(WebSocketEvent.Eew, (e) => {
       lat: e.eq.lat,
       lng: e.eq.lon,
     })({ lng: area.lng, lat: area.lat })(e.eq.depth);
-    const localExpectedIntensity = calculateIntensity(
-      surfaceDistance,
-      distance,
-      e.eq.mag,
-      e.eq.depth
-    );
 
     data.surface = surfaceDistance;
     data.distance = distance;
-    data.i = roundIntensity(localExpectedIntensity);
+    data.i = intensity[config.cache.location.area];
 
     let { p, s } = calculateLocalExpectedWaveTime(
       data.distance,

--- a/src/scripts/helper/utils.ts
+++ b/src/scripts/helper/utils.ts
@@ -262,7 +262,8 @@ export const calculateExpectedIntensity = (
         surfaceDistance,
         distance,
         magnitude,
-        depth
+        depth,
+        town.site
       );
 
       if (int > maxIntensity) {


### PR DESCRIPTION
Hi,

I've noticed a potential issue in the code where the regional site effect parameters might not be incorporated into the PGA formula. This is fixed by 8a9f0adb70575b115b271fc243c94bc5c7097b0e

Currently, the parameter seems to default to 1.751.

If this observation is correct, it could potentially lead to less precise seismic response calculations for various regions.

I believe integrating specific site effect parameters for each area could enhance the accuracy of our earthquake impact assessments.

https://github.com/ExpTechTW/TREM-tauri/blob/8a9f0adb70575b115b271fc243c94bc5c7097b0e/src/scripts/helper/utils.ts#L200-L208


There's also a small optimization: 009c6667e1d10ebbdf39ea32b94f7b2ad0df9c7f
We can use the intensity map to get local intensity without re-calculation.